### PR TITLE
Support for multiple values under each node of the tree.

### DIFF
--- a/RadixTreeTester/radixtree/RadixTreeNode.h
+++ b/RadixTreeTester/radixtree/RadixTreeNode.h
@@ -23,11 +23,14 @@
  */
 
 @interface RadixTreeNode : NSObject
-@property id value;
+@property (nonatomic, strong, readonly) NSArray *values;
 @property NSString* key;
 
 @property Boolean isReal;
 @property NSMutableArray *children;
 
 -(int)numberOfMatchingCharacters:(NSString*)key;
+- (void)addValue:(id)value;
+- (void)setValues:(NSArray *)values;
+
 @end

--- a/RadixTreeTester/radixtree/RadixTreeNode.m
+++ b/RadixTreeTester/radixtree/RadixTreeNode.m
@@ -24,6 +24,12 @@
 
 #import "RadixTreeNode.h"
 
+@interface RadixTreeNode ()
+
+@property (nonatomic, strong) NSMutableArray *nodeValues;
+
+@end
+
 @implementation RadixTreeNode
     /**
      * intailize the fields with default values to avoid null reference checks
@@ -51,6 +57,41 @@
     }
     
     return numberOfMatchingCharacters;
+}
+
+- (NSMutableArray *)nodeValues
+{
+    if (!_nodeValues)
+    {
+        _nodeValues = [NSMutableArray new];
+    }
+    return _nodeValues;
+}
+
+- (void)addValue:(id)value
+{
+    [self.nodeValues addObject:value];
+}
+
+- (void)setValues:(NSArray *)values
+{
+    self.nodeValues = [values mutableCopy];
+}
+
+- (NSArray *)values
+{
+    if ([self.nodeValues count] == 1)
+    {
+        return @[self.nodeValues[0]];
+    }
+    else if ([self.nodeValues count] == 0)
+    {
+        return nil;
+    }
+    else
+    {
+        return [self.nodeValues copy];
+    }
 }
 
 -(NSString *)description {

--- a/RadixTreeTester/radixtree/Visitor.h
+++ b/RadixTreeTester/radixtree/Visitor.h
@@ -44,6 +44,8 @@ typedef void (^VisitBlock)(Visitor *visitor, NSString *key, RadixTreeNode *paren
 
 -(void)visit:(NSString *)key parent:(RadixTreeNode *)parent node:(RadixTreeNode *)node;
 
-@property (nonatomic, strong) id result;
+- (void)addResult:(id)result;
+- (void)setResults:(NSArray *)results;
+- (NSMutableArray *)results;
 
 @end

--- a/RadixTreeTester/radixtree/Visitor.m
+++ b/RadixTreeTester/radixtree/Visitor.m
@@ -10,6 +10,9 @@
 @interface Visitor() {
     VisitBlock _visitBlock;
 }
+
+@property (nonatomic, strong) NSMutableArray *visitorResults;
+
 @end
 
 @implementation Visitor
@@ -28,6 +31,37 @@
     if (_visitBlock) {
         _visitBlock(self, key, parent, node);
     }
+}
+
+- (void)addResult:(id)result
+{
+    [self.visitorResults addObject:result];
+}
+
+- (void)setResults:(NSArray *)results
+{
+    _visitorResults = [results mutableCopy];
+}
+
+- (NSMutableArray *)results
+{
+    if ([self.visitorResults count] == 0)
+    {
+        return nil;
+    }
+    else
+    {
+        return [self.visitorResults mutableCopy];
+    }
+}
+
+- (NSMutableArray *)visitorResults
+{
+    if (!_visitorResults)
+    {
+        _visitorResults = [NSMutableArray new];
+    }
+    return _visitorResults;
 }
 
 @end

--- a/RadixTreeTesterTests/RadixTreeTesterTests.m
+++ b/RadixTreeTesterTests/RadixTreeTesterTests.m
@@ -30,31 +30,31 @@
     [trie insert:@"abcd" value:@"abcd"];
     [trie insert:@"abce" value:@"abce"];
     
-    STAssertEquals(0U, [trie searchPrefix:@"abe" recordLimit:10].count, @"");
-    STAssertEquals(0U, [trie searchPrefix:@"abd" recordLimit:10].count, @"");
+    [self assertArray:[trie searchPrefix:@"abe" recordLimit:10] hasSize:0];
+    [self assertArray:[trie searchPrefix:@"abd" recordLimit:10] hasSize:0];
 }
 
 -(void)testSearchForLeafNodesWhenOverlapExists {
     [trie insert:@"abcd" value:@"abcd"];
     [trie insert:@"abce" value:@"abce"];
     
-    STAssertEquals(1U, [trie searchPrefix:@"abcd" recordLimit:10].count, @"");
-    STAssertEquals(1U, [trie searchPrefix:@"abce" recordLimit:10].count, @"");
+    [self assertArray:[trie searchPrefix:@"abcd" recordLimit:10] hasSize:1];
+    [self assertArray:[trie searchPrefix:@"abce" recordLimit:10] hasSize:1];
 }
 
 -(void)testSearchForStringSmallerThanSharedParentWhenOverlapExists {
     [trie insert:@"abcd" value:@"abcd"];
     [trie insert:@"abce" value:@"abce"];
     
-    STAssertEquals(2U, [trie searchPrefix:@"ab" recordLimit:10].count, @"");
-    STAssertEquals(2U, [trie searchPrefix:@"a" recordLimit:10].count, @"");
+    [self assertArray:[trie searchPrefix:@"ab" recordLimit:10] hasSize:2];
+    [self assertArray:[trie searchPrefix:@"a" recordLimit:10] hasSize:2];
 }
 
 -(void)testSearchForStringEqualToSharedParentWhenOverlapExists {
     [trie insert:@"abcd" value:@"abcd"];
     [trie insert:@"abce" value:@"abce"];
     
-    STAssertEquals(2U, [trie searchPrefix:@"abc" recordLimit:10].count, @"");
+    [self assertArray:[trie searchPrefix:@"abc" recordLimit:10] hasSize:2];
 }
 
 -(void)testInsert {
@@ -101,8 +101,8 @@
     [trie insert:@"xbox 360 xbox 360" value:@"xbox 360 xbox 360"];
     [trie insert:@"360 xbox games 360" value:@"360 xbox games 360"];
     [trie insert:@"xbox xbox 361" value:@"xbox xbox 361"];
-    
-    STAssertEquals(12U, trie.count, @"");
+
+    STAssertTrue(trie.count == 12, @"");
 }
 
 -(void)testDeleteNodeWithNoChildren {
@@ -231,7 +231,7 @@
     [trie insert:@"ape" value:@"ape"];
     
     NSArray *result = [trie searchPrefix:@"app" recordLimit:10];
-    STAssertEquals(4U, result.count, @"");
+    [self assertArray:result hasSize:4];
     
     STAssertTrue([result indexOfObject:@"appleshack"] != NSNotFound, @"");
     STAssertTrue([result indexOfObject:@"appleshackcream"] != NSNotFound, @"");
@@ -247,7 +247,7 @@
     [trie insert:@"ape" value:@"ape"];
     
     NSArray *result = [trie searchPrefix:@"appl" recordLimit:3];
-    STAssertEquals(3U, result.count, @"");
+    [self assertArray:result hasSize:3];
     
     STAssertTrue([result indexOfObject:@"appleshack"] !=  NSNotFound, @"");
     STAssertTrue([result indexOfObject:@"applepie"] !=  NSNotFound, @"");
@@ -271,6 +271,25 @@
     [trie delete:@"appleshack"];
     
     STAssertTrue(trie.count == 1, @"");
+}
+
+- (void)assertArray:(NSArray *)results hasSize:(NSUInteger)size
+{
+    STAssertTrue([results count] == size, @"");
+}
+
+- (void)testFindWithVariousValuesForSingleKey
+{
+    [trie insert:@"apple" value:@"apple"];
+    [trie insert:@"apple" value:@"pie"];
+    [self assertArray:[trie find:@"apple"] hasSize:2];
+}
+
+- (void)testPrefixWithVariousValuesForSingleKey
+{
+    [trie insert:@"apple" value:@"apple"];
+    [trie insert:@"apple" value:@"pie"];
+    [self assertArray:[trie searchPrefix:@"ap" recordLimit:10] hasSize:2];
 }
 
 -(void)testComplete {


### PR DESCRIPTION
I added support to store multiple values under each node of the tree. The tree's interface remains the same, but now, adding a value using a key that already exists in the tree, adds this value to the node rather than replacing the currently stored in it.

Behavior changes in the following methods:

-(BOOL) insert:(NSString*)key value:value;

  As I said, if the node with the key "key" exists, the value is added to this node, maintaining previous values stored in it.

-(id) find:(NSString*)key;

  Now, this method can return an array of objects which are stored under the node that matches the key. If there's only a single value under this node, this method returns this object (not an array with a single object), so the previous behavior is maintained.

-(NSArray*)searchPrefix:(NSString *)prefix recordLimit:(int)maxLimit;

  Now, this method can add to the results more than one value for each matching node.
